### PR TITLE
Keep curl package for health-checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,6 @@ RUN apk add --update                                    \
     apk del                                             \
       ca-certificates                                   \
       gzip                                              \
-      curl                                              \
       wget                                          &&  \
     # Clean caches and tmps
     rm -rf /var/cache/apk/*                         &&  \


### PR DESCRIPTION
If using docker-compose.yml healthcheck, the normal is to use curl to check app health.

See: https://docs.docker.com/compose/compose-file/#healthcheck