### PR TITLE
Allow configuration of the JIRA port on the server side.

### DIFF
--- a/imagescripts/docker-entrypoint.sh
+++ b/imagescripts/docker-entrypoint.sh
@@ -78,6 +78,10 @@ if [ -n "${JIRA_PROXY_SCHEME}" ]; then
   xmlstarlet ed -P -S -L --insert "//Connector[not(@scheme)]" --type attr -n scheme --value "${JIRA_PROXY_SCHEME}" ${JIRA_INSTALL}/conf/server.xml
 fi
 
+if [ -n "${JIRA_PORT}" ]; then
+  xmlstarlet ed --inplace --pf --ps --update '//Connector/@port' --value "${JIRA_PORT}" "${JIRA_INSTALL}/conf/server.xml"
+fi
+
 jira_logfile="/var/atlassian/jira/log"
 
 if [ -n "${JIRA_LOGFILE_LOCATION}" ]; then


### PR DESCRIPTION
Contributing my enhancement which allows multiple JIRA instances to be run on a single server by combining Docker with proxying. To do this you need to be able to configure the default server-side JIRA port (8080) to be something else. 