### PR TITLE
Database connection fixes (SQL Server; Validation query)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,26 @@ $ docker run -d --name jira \
 
 >  Start the Jira and link it to the mysql instance.
 
+## SQL Server
+
+Starting with version 7.8.0 of JIRA, Atlassian no longer provides/uses the jTDS JDBC driver and instead bundles the Microsoft JDBC driver.  This proves to be a bit of a headache because while the jTDS driver used the
+conventional JDBC URL scheme, Microsoft's driver uses a non-standard JDBC URL scheme that departs wildly from the usual (see [Issue #72](https://github.com/blacklabelops/jira/issues/72) for details).  As a result of 
+this deviation from the standard, users wishing to connect to a SQL Server database *MUST* encode their host/port/database information in the `JIRA_DATABASE_URL` and cannot leverage the individual 
+`JIRA_DB_*` variables.  Note that any additional driver properties needed can be appended in much the same was as `databaseName` is handled in the example below.
+
+~~~~
+docker run \
+    -d \
+    --name jira \
+    --network jiranet \
+    -v jiravolume:/var/atlassian/jira \
+    -e "JIRA_DATABASE_URL=sqlserver://MySQLServerHost:1433;databaseName=MyDatabase" \
+    -e "JIRA_DB_USER=jira-app" \
+    -e "JIRA_DB_PASSWORD=***" \
+    -p 8080:8080 \
+    blacklabelops/jira
+~~~~
+
 # Database Wait Feature
 
 A Jira container can wait for the database container to start up. You have to specify the

--- a/imagescripts/common.sh
+++ b/imagescripts/common.sh
@@ -66,6 +66,7 @@ extract_database_url() {
       local jdbc_url="jdbc:postgresql://$host_port_name"
       local hibernate_dialect="org.hibernate.dialect.PostgreSQLDialect"
       local database_type="postgres72"
+      local validation_query="select version();"
       ;;
     mysql|mysql2)
       if [ -z "$(read_var $prefix PORT)" ]; then
@@ -76,16 +77,14 @@ extract_database_url() {
       local jdbc_url="jdbc:mysql://$host_port_name?autoReconnect=true&characterEncoding=utf8&useUnicode=true&sessionVariables=default_storage_engine%3DInnoDB"
       local hibernate_dialect="org.hibernate.dialect.MySQLDialect"
       local database_type="mysql"
+      local validation_query="select 1"
       ;;
     sqlserver)
-      if [ -z "$(read_var $prefix PORT)" ]; then
-        eval "${prefix}_PORT=1433"
-      fi
-      local host_port_name="$(read_var $prefix HOST):$(read_var $prefix PORT)/$(read_var $prefix NAME)"
       local jdbc_driver="com.microsoft.sqlserver.jdbc.SQLServerDriver"
-      local jdbc_url="jdbc:sqlserver://$host_port_name"
+      local jdbc_url="jdbc:$url"
       local hibernate_dialect="org.hibernate.dialect.SQLServerDialect"
       local database_type="mssql"
+      local validation_query="select 1"
       ;;
     *)
       echo "Unsupported database url scheme: $(read_var $prefix SCHEME)"
@@ -97,4 +96,6 @@ extract_database_url() {
   eval "${prefix}_JDBC_URL=\"$jdbc_url\""
   eval "${prefix}_DIALECT=\"$hibernate_dialect\""
   eval "${prefix}_TYPE=\"$database_type\""
+  eval "${prefix}_VALIDATION_QUERY=\"$validation_query\""
+
 }

--- a/imagescripts/launch.sh
+++ b/imagescripts/launch.sh
@@ -43,7 +43,7 @@ if [ -n "$JIRA_DATABASE_URL" ]; then
     <pool-max-idle>20</pool-max-idle>
     <pool-remove-abandoned>true</pool-remove-abandoned>
     <pool-remove-abandoned-timeout>300</pool-remove-abandoned-timeout>
-    <validation-query>select version();</validation-query>
+    <validation-query>$JIRA_DB_VALIDATION_QUERY</validation-query>
     <validation-query-timeout>3</validation-query-timeout>
     <min-evictable-idle-time-millis>60000</min-evictable-idle-time-millis>
     <time-between-eviction-runs-millis>300000</time-between-eviction-runs-millis>


### PR DESCRIPTION
### Description of the Change

Atlassian has switched the JDBC SQL Server driver they include for JIRA and documented the changes needed (mainly changing the form of the JDBC URL and the Java className of the driver class).  This PR covers adjusting the Docker image to account for these changes.  Additionally this PR includes a fix/enhancement that makes the JDBC connection pool validation query overridable across database versions.

### Verification Process

Tested locally using SQL Server 2014

### Applicable Issues

 - #72 - Fails for SQL Server (new JDBC driver from Atlassian)
