### PR TITLE
Bump to Core/Software 7.8.1 and Service Desk 3.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
 # Note that you also need to update buildscripts/release.sh when the
 # Jira version changes
-ARG JIRA_VERSION=7.8.0
+ARG JIRA_VERSION=7.8.1
 ARG JIRA_PRODUCT=jira-software
 # Permissions, set the linux user id and group id
 ARG CONTAINER_UID=1000

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 | Product |Version | Tags  | Dockerfile |
 |---------|--------|-------|------------|
-| Jira Software | 7.8.0 | 7.8.0, latest, latest.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
-| Jira Service Desk | 3.11.0 | servicedesk, servicedesk.3.11.0, servicedesk.de, servicedesk.3.11.0.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
-| Jira Core | 7.8.0 | core, core.7.8.0, core.de, core.7.8.0.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Software | 7.8.1 | 7.8.1, latest, latest.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Service Desk | 3.11.1 | servicedesk, servicedesk.3.11.1, servicedesk.de, servicedesk.3.11.1.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Core | 7.8.1 | core, core.7.8.1, core.de, core.7.8.1.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
 
 > Older tags remain but are not supported/rebuild.
 

--- a/buildscripts/release.sh
+++ b/buildscripts/release.sh
@@ -3,6 +3,6 @@
 #------------------
 # CONTAINER VARIABLES
 #------------------
-export JIRA_VERSION=7.8.0
-export JIRA_SERVICE_DESK_VERSION=3.11.0
+export JIRA_VERSION=7.8.1
+export JIRA_SERVICE_DESK_VERSION=3.11.1
 export JIRA_DEVELOPMENT_TAG=development


### PR DESCRIPTION
### Description of the Change

Bump versions to:

- Core/Software: 7.8.1
- Service Desk: 3.11.1

### Verification Process

```
docker build -t blacklabelops/jira .
```

### Applicable Issues

- https://confluence.atlassian.com/jiracore/issues-resolved-in-7-8-1-947165858.html
- https://confluence.atlassian.com/jirasoftware/issues-resolved-in-7-8-1-947165844.html
- https://confluence.atlassian.com/servicedesk/issues-resolved-in-3-11-1-947165885.html