### PR TITLE
Bump to Dockerize 0.6.1 and MySQL driver 5.1.46

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV JIRA_USER=jira                            \
     JIRA_HOME=/var/atlassian/jira             \
     JIRA_INSTALL=/opt/jira                    \
     JIRA_SCRIPTS=/usr/local/share/atlassian   \
-    MYSQL_DRIVER_VERSION=5.1.44               \
+    MYSQL_DRIVER_VERSION=5.1.46               \
     DOCKERIZE_VERSION=v0.6.1
 ENV JAVA_HOME=$JIRA_INSTALL/jre
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV JIRA_USER=jira                            \
     JIRA_INSTALL=/opt/jira                    \
     JIRA_SCRIPTS=/usr/local/share/atlassian   \
     MYSQL_DRIVER_VERSION=5.1.44               \
-    DOCKERIZE_VERSION=v0.4.0
+    DOCKERIZE_VERSION=v0.6.1
 ENV JAVA_HOME=$JIRA_INSTALL/jre
 
 ENV PATH=$PATH:$JAVA_HOME/bin \


### PR DESCRIPTION
### Description of the Change

Bump versions to:

- Dockerize: 0.6.1
- MySQL driver: 5.1.46

### Verification Process

```
docker build -t blacklabelops/jira .
```

### Applicable Issues

- https://github.com/jwilder/dockerize/releases/tag/v0.6.1
- https://dev.mysql.com/downloads/connector/j/