### PR TITLE
Fixing the urldecode does not replace %40 back to @

### DIFF
--- a/imagescripts/common.sh
+++ b/imagescripts/common.sh
@@ -1,6 +1,6 @@
 urldecode() {
     local data=${1//+/ }
-    printf '%b' "${data//%/\x}"
+    printf '%b' "${data//%/\\x}"
 }
 
 parse_url() {


### PR DESCRIPTION
### Requirements

### Description of the Change

Fixing #89 , the error where a slash was missing in url decode. without that %40 will become x40. 

### Verification Process
I built a container with the fix and saw the value after url decode to be right
-->

### Applicable Issues

