### PR TITLE
Jira 7.11.0 and Service Desk 3.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
 # Note that you also need to update buildscripts/release.sh when the
 # Jira version changes
-ARG JIRA_VERSION=7.10.2
+ARG JIRA_VERSION=7.11.0
 ARG JIRA_PRODUCT=jira-software
 # Permissions, set the linux user id and group id
 ARG CONTAINER_UID=1000

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 | Product |Version | Tags  | Dockerfile |
 |---------|--------|-------|------------|
-| Jira Software | 7.10.2 | 7.10.2, latest, latest.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
-| Jira Service Desk | 3.13.2 | servicedesk, servicedesk.3.13.2, servicedesk.de, servicedesk.3.13.2.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
-| Jira Core | 7.10.2 | core, core.7.10.2, core.de, core.7.10.2.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Software | 7.11.0 | 7.11.0, latest, latest.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Service Desk | 3.14.0 | servicedesk, servicedesk.3.14.0, servicedesk.de, servicedesk.3.14.0.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Core | 7.11.0 | core, core.7.11.0, core.de, core.7.11.0.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
 
 > Older tags remain but are not supported/rebuild.
 

--- a/buildscripts/release.sh
+++ b/buildscripts/release.sh
@@ -3,6 +3,6 @@
 #------------------
 # CONTAINER VARIABLES
 #------------------
-export JIRA_VERSION=7.10.2
-export JIRA_SERVICE_DESK_VERSION=3.13.2
+export JIRA_VERSION=7.11.0
+export JIRA_SERVICE_DESK_VERSION=3.14.0
 export JIRA_DEVELOPMENT_TAG=development


### PR DESCRIPTION
### Description of the Change

Bump versions to:

- Jira: 7.11.0
- Service Desk: 3.14.0

### Verification Process

```
docker build -t blacklabelops/jira .
```

### Release notes
- Jira: https://confluence.atlassian.com/jirasoftware/jira-software-7-11-x-release-notes-952600888.html
- Service Desk: https://confluence.atlassian.com/servicedesk/jira-service-desk-3-14-x-release-notes-952618829.html