### PR TITLE
Jira 7.12.2 and Service Desk 3.15.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
 # Note that you also need to update buildscripts/release.sh when the
 # Jira version changes
-ARG JIRA_VERSION=7.12.1
+ARG JIRA_VERSION=7.12.2
 ARG JIRA_PRODUCT=jira-software
 # Permissions, set the linux user id and group id
 ARG CONTAINER_UID=1000

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 | Product |Version | Tags  | Dockerfile |
 |---------|--------|-------|------------|
-| Jira Software | 7.12.1 | 7.12.1, latest, latest.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
-| Jira Service Desk | 3.15.1 | servicedesk, servicedesk.3.15.1, servicedesk.de, servicedesk.3.15.1.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
-| Jira Core | 7.12.1 | core, core.7.12.1, core.de, core.7.12.1.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Software | 7.12.2 | 7.12.2, latest, latest.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Service Desk | 3.15.2 | servicedesk, servicedesk.3.15.2, servicedesk.de, servicedesk.3.15.2.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Core | 7.12.2 | core, core.7.12.2, core.de, core.7.12.2.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
 
 > Older tags remain but are not supported/rebuild.
 

--- a/buildscripts/release.sh
+++ b/buildscripts/release.sh
@@ -3,6 +3,6 @@
 #------------------
 # CONTAINER VARIABLES
 #------------------
-export JIRA_VERSION=7.12.1
-export JIRA_SERVICE_DESK_VERSION=3.15.1
+export JIRA_VERSION=7.12.2
+export JIRA_SERVICE_DESK_VERSION=3.15.2
 export JIRA_DEVELOPMENT_TAG=development


### PR DESCRIPTION
### Description of the Change

Bump versions to:

- Jira: 7.12.2
- Service Desk: 3.15.2

### Verification Process

```
docker build -t blacklabelops/jira .
```

### Release notes
- Jira: https://confluence.atlassian.com/jirasoftware/jira-software-7-12-x-release-notes-953676636.html
- Service Desk: https://confluence.atlassian.com/servicedesk/jira-service-desk-3-15-x-release-notes-955163679.html