### PR TITLE
Up Docker Compose version to 3.5; add default names for containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
-version: '3'
+version: '3.5'
 
 services:
   jira:
     depends_on:
       - postgresql
     image: blacklabelops/jira
+    container_name: jira
     networks:
       - jiranet
     volumes:
@@ -31,6 +32,7 @@ services:
 
   postgresql:
     image: blacklabelops/postgres
+    container_name: postgresql
     networks:
       - jiranet
     volumes:
@@ -61,4 +63,5 @@ volumes:
 
 networks:
   jiranet:
+    name: jiranet
     driver: bridge


### PR DESCRIPTION
Use default names for containers and network. In order to use this, had to bump the [Docker Compose](https://docs.docker.com/compose/compose-file/) version to 3.5.

Note: This may have an undesirable side-effect. Per the documentation:

> Because Docker container names must be unique, you cannot scale a service beyond 1 container if you have specified a custom name. Attempting to do so results in an error.

This doesn't affect me but it might others.