### PR TITLE
Upgrade to JIRA 7.13.0 (Enterprise Release)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
 # Note that you also need to update buildscripts/release.sh when the
 # Jira version changes
-ARG JIRA_VERSION=7.12.3
+ARG JIRA_VERSION=7.13.0
 ARG JIRA_PRODUCT=jira-software
 # Permissions, set the linux user id and group id
 ARG CONTAINER_UID=1000
@@ -20,7 +20,7 @@ ENV JIRA_USER=jira                            \
     JIRA_HOME=/var/atlassian/jira             \
     JIRA_INSTALL=/opt/jira                    \
     JIRA_SCRIPTS=/usr/local/share/atlassian   \
-    MYSQL_DRIVER_VERSION=5.1.46               \
+    MYSQL_DRIVER_VERSION=5.1.47               \
     DOCKERIZE_VERSION=v0.6.1
 ENV JAVA_HOME=$JIRA_INSTALL/jre
 
@@ -37,7 +37,7 @@ RUN apk add --update                                    \
       wget                                              \
       xmlstarlet                                    &&  \
     # Install latest glibc
-    export GLIBC_VERSION=2.26-r0 && \
+    export GLIBC_VERSION=2.28-r0 && \
     wget --directory-prefix=/tmp https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
     apk add --allow-untrusted /tmp/glibc-${GLIBC_VERSION}.apk && \
     wget --directory-prefix=/tmp https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk && \

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 | Product |Version | Tags  | Dockerfile |
 |---------|--------|-------|------------|
-| Jira Software | 7.12.3 | 7.12.3, latest, latest.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
-| Jira Service Desk | 3.15.3 | servicedesk, servicedesk.3.15.3, servicedesk.de, servicedesk.3.15.3.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
-| Jira Core | 7.12.3 | core, core.7.12.3, core.de, core.7.12.3.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Software | 7.13.0 | 7.13.0, latest, latest.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Service Desk | 3.16.0 | servicedesk, servicedesk.3.16.0, servicedesk.de, servicedesk.3.16.0.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
+| Jira Core | 7.13.0 | core, core.7.13.0, core.de, core.7.13.0.de | [Dockerfile](https://github.com/blacklabelops/jira/blob/master/Dockerfile) |
 
 > Older tags remain but are not supported/rebuild.
 

--- a/buildscripts/release.sh
+++ b/buildscripts/release.sh
@@ -3,6 +3,6 @@
 #------------------
 # CONTAINER VARIABLES
 #------------------
-export JIRA_VERSION=7.12.3
-export JIRA_SERVICE_DESK_VERSION=3.15.3
+export JIRA_VERSION=7.13.0
+export JIRA_SERVICE_DESK_VERSION=3.16.0
 export JIRA_DEVELOPMENT_TAG=development


### PR DESCRIPTION
### Description of the Change

* Upgrade to JIRA 7.13.0 and JIRA Service Desk 3.16.0 release.
* Upgrade GLIBC to 2.28-r0 release
* Upgrade MySQL JDBC to 5.1.47

### Verification Process

1) Container builds cleanly.
2) JIRA starts up, licence install works and demo project loads.
