### PR TITLE
Update postgres connections to use tcpKeepAlive and socketTimeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN export GLIBC_VERSION=2.29-r0                               \
     && export MYSQL_FILE_TAR=$MYSQL_FILE_BASE.tar.gz           \
     && export MYSQL_FILE_BIN=$MYSQL_FILE_BASE-bin.jar          \
     && export MYSQL_DOWNLOAD_URL=https://dev.mysql.com/get/Downloads/Connector-J/$MYSQL_FILE_TAR \
-    && export POSTGRESQL_DRIVER_VERSION=42.2.5                 \
+    && export POSTGRESQL_DRIVER_VERSION=42.4.0                 \
     && export POSTGRESQL_FILE=postgresql-$POSTGRESQL_DRIVER_VERSION.jar \
     && export POSTGRESQL_DOWNLOAD_URL=https://jdbc.postgresql.org/download/$POSTGRESQL_FILE \
     && rm -f $JIRA_LIB/mysql-connector-java*.jar               \

--- a/bin/launch.sh
+++ b/bin/launch.sh
@@ -24,6 +24,10 @@ if [ -n "$JIRA_DATABASE_URL" ]; then
   if [ "$JIRA_DB_TYPE" == "mssql" ]; then
     SCHEMA='<schema-name>dbo</schema-name>'
   fi
+  case $JIRA_DB_TYPE in postgres*)
+    # see https://confluence.atlassian.com/jirakb/connection-problems-to-postgresql-result-in-stuck-threads-in-jira-1047534091.html
+    PG_CONN_PROPERTIES="<connection-properties>tcpKeepAlive=true;socketTimeout=240</connection-properties>"
+  esac
 
   cat <<END > ${JIRA_HOME}/dbconfig.xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -49,6 +53,7 @@ if [ -n "$JIRA_DATABASE_URL" ]; then
     <time-between-eviction-runs-millis>300000</time-between-eviction-runs-millis>
     <pool-test-on-borrow>false</pool-test-on-borrow>
     <pool-test-while-idle>true</pool-test-while-idle>
+    $PG_CONN_PROPERTIES
   </jdbc-datasource>
 </jira-database-config>
 END


### PR DESCRIPTION
This fixes potential stuck threads in "some situations", as documented
by Atlassian here:

https://confluence.atlassian.com/jirakb/connection-problems-to-postgresql-result-in-stuck-threads-in-jira-1047534091.html

----
Doing this required two things:

1.  Updating the postgres jar file (latest is currently 42.4.0)
2. Adding the indicated `<connection-properties>` when using postgres

This works well in my testing... with the only thing being that I'm not yet sure why the container still has the old 42.2.25 jar in it:

```bash
$ docker exec -it jira bash
bash-5.1$ find / -name "postgres*jar" 2>/dev/null
/opt/jira/lib/postgresql-42.4.0.jar
/opt/jira/lib/postgresql-42.2.25.jar
bash-5.1$
```